### PR TITLE
close #155 - Fix the exception when APIs are deployed remotely

### DIFF
--- a/slimapp/public/index.php
+++ b/slimapp/public/index.php
@@ -1,4 +1,4 @@
-<?php
+<?php header('Access-Control-Allow-Origin: *');
 use \Psr\Http\Message\ServerRequestInterface as Request;
 use \Psr\Http\Message\ResponseInterface as Response;
 


### PR DESCRIPTION
close #155 
- Problem: the APIs did not work when being deployed on a remote server.
- Root cause: the access control is not allow across domain.
- Solution: Fix by adding header('Access-Control-Allow-Origin: *') to the PHP file.