### PR TITLE
close #201 - Data Query test - Remove codes commented out

### DIFF
--- a/Website/dashboard/DataQuery.php
+++ b/Website/dashboard/DataQuery.php
@@ -13,7 +13,6 @@ class DataQuery
     	$curl_response = curl_exec($curl);    	
     	curl_close($curl);
     	return $curl_response;
-    	//print_r($curl_response);
     }
  
 }

--- a/Website/dashboard/DataQueryTest.php
+++ b/Website/dashboard/DataQueryTest.php
@@ -144,7 +144,6 @@ class DataQueryTests extends TestCase
     	$url = 'http://studata.tk/slimapp/public/index.php/api/events/search?parameters=' . $parameters;
     	$result = $this->dataQuery->callAPI($url, null);
     	
-    	//print_r($result);
     	// assert if two values are equal
     	$this->assertEquals($expectedResult, $result);
     }


### PR DESCRIPTION
close #201 
- Problem: some codes which were commented out are still in codes of Data Query module.
- Solution: remove all redundant codes which were commented out in Data Query module.