### PR TITLE
Clarify label, button, drop-down box names

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Our database is given by clients which include <b>forum CSV files</b> and <b>web
 
 Following points are what we have done to solve the problem we deiscribed above.
 
-<li> We provide <a href="http://www.studata.tk/demo/pages/Moodlecharts.html">Moodle Charts </a> to show the students forum activities by charts.
+<li> We provide Moodle Charts (<a href="http://studata.tk/dashboard/MoodleCharts.html"> Original version (Working version) </a>,<a href="http://www.studata.tk/demo/pages/Moodlecharts.html"> Another version </a>) to show students' forum activities by charts.
 
-<li> We provide <a href="http://www.studata.tk/demo/pages/WebSubmissionCharts.html">Websubmission Charts</a> to show the students websubmisson destribution by charts.
+<li> We provide Websubmission Charts (<a href="http://studata.tk/dashboard/WebSubmissionCharts.html"> Original version </a>,<a href="http://studata.tk/demo/pages/WebSubmissionCharts.html"> Another version </a>) to show students' submission by charts.
 
 <li> We provide <a href="http://www.studata.tk/dashboard/CriticalQuestions.html">Critical Questions</a> to show the realtionships between students forum activities and websubmissions.
 

--- a/Website/dashboard/CriticalQuestions.html
+++ b/Website/dashboard/CriticalQuestions.html
@@ -26,20 +26,12 @@
             aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <a class="navbar-brand" href="#">Dashboard</a>
   <div class="collapse navbar-collapse" id="navbarsExampleDefault">
     <ul class="navbar-nav mr-auto">
 	  <li class="nav-item active">
-	    <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
-	  </li>
-	  <li class="nav-item">
-	    <a class="nav-link" href="../index.html">Back</a>
+	    <a class="nav-link" href="../demo/index.html">Back</a>
 	  </li>
     </ul>
-    <form class="form-inline mt-2 mt-md-0">
-      <input class="form-control mr-sm-2" type="text" placeholder="Search">
-      <button class="btn btn-info" type="submit">Search</button>
-    </form>
   </div>
 </nav>
 
@@ -473,7 +465,7 @@ $(document).ready(function() {
 		});//ajax
 	})//$('#QuestionOneFilter').click
 
-//calculate and print Pearson Correlation Coefficient and data in table
+	//calculate and print Pearson Correlation Coefficient and data in table
 	$('#QuestionOneGetAnswer').click(function () {
 		var SelectCourse=$("#SelectCourse option:selected").attr("id");
 		var SelectYear=$("#SelectYear option:selected").attr("id");

--- a/Website/dashboard/CriticalQuestions.html
+++ b/Website/dashboard/CriticalQuestions.html
@@ -64,15 +64,19 @@
 	  <select id="SelectSemester">
 	    <option  id="PleaseSelectSemester">SelectSemester</option>
 	  </select>
-	  <div id="SemesterInformation">
-        </br>
-	    <label>Semester start day (YYYYMMDD):</label>
-	    <label id="SemesterStartDay"></label>
-		</br>
-		<label>Semester end day (YYYYMMDD):</label>
-	    <label id="SemesterEndDay"></label>
-	  </div>
-	  <div id="AssignmentInformation">
+	  </br></br>
+	  <button id="Hide">Show/Hide Semester and Assignments start/end day</button>
+	  <div id="SemesterAndAssignmentInformation" style="display:none">
+	    <div id="SemesterInformation">
+          </br>
+	      <label>Semester start day (YYYYMMDD):</label>
+	      <label id="SemesterStartDay"></label>
+		  </br>
+		  <label>Semester end day (YYYYMMDD):</label>
+	      <label id="SemesterEndDay"></label>
+	    </div>
+	    <div id="AssignmentInformation">
+	    </div>
 	  </div>
 	  </br></br>
 	  <h3>Critical question 1: </br> 
@@ -122,6 +126,10 @@
 	  
 <script type="text/javascript">
 $(document).ready(function() {
+	$("#Hide").click(function(){
+		$("#SemesterAndAssignmentInformation").toggle();
+	});
+
 	//Load data for select course
 	$.ajax({
 		type: "get",

--- a/Website/dashboard/CriticalQuestions.html
+++ b/Website/dashboard/CriticalQuestions.html
@@ -107,7 +107,7 @@
 		  <input type="text" id="QuestionOneTo">
 	  </div>
 	  </br>
-      <button type="button" id="QuestionOneFilter">Filter Event name and Event context</button>&nbsp
+      <button type="button" id="QuestionOneFilter">Update</button>&nbsp
 	  <button type="button" id="QuestionOneGetAnswer">Get answer</button>
 	  </br></br>
 	  <div id="R">

--- a/Website/dashboard/CriticalQuestions.html
+++ b/Website/dashboard/CriticalQuestions.html
@@ -69,11 +69,10 @@
 	  <div id="SemesterAndAssignmentInformation" style="display:none">
 	    <div id="SemesterInformation">
           </br>
-	      <label>Semester start day (YYYYMMDD):</label>
-	      <label id="SemesterStartDay"></label>
+	      <label>Semester start day/end day (YYYYMMDD):</label>
+	      <label id="SemesterStartDay"></label>/
+		  <label id="SemesterEndDay"></label>
 		  </br>
-		  <label>Semester end day (YYYYMMDD):</label>
-	      <label id="SemesterEndDay"></label>
 	    </div>
 	    <div id="AssignmentInformation">
 	    </div>
@@ -528,8 +527,7 @@ function displayAssignmentInformation() {
 		success: function (result) {
 			$("#AssignmentInformation").empty();
 			$.each(result, function (i, p) {
-				$("#AssignmentInformation").append("<p>"+p['AssignmentName']+" start day (YYYYMMDD): "+p['StartDate']+"</p>"); 
-				$("#AssignmentInformation").append("<p>"+p['AssignmentName']+" due day (YYYYMMDD): "+p['DueDate']+"</p>"); 
+				$("#AssignmentInformation").append("<p>"+p['AssignmentName']+" start day/due day (YYYYMMDD): "+p['StartDate']+"/ "+p['DueDate']+"</p>"); 
 			});
 		}//success
 	});//ajax

--- a/Website/dashboard/DataQuery.html
+++ b/Website/dashboard/DataQuery.html
@@ -16,10 +16,10 @@
   
   <!-- Custom styles for this template -->
   <link href="../css/dashboard1.css" rel="stylesheet">
-  <link rel="stylesheet" href="../js/jquery-ui.min.css">
-  <link rel="stylesheet" href="../js/jquery-ui.structure.min.css">
-  <link rel="stylesheet" href="../js/jquery-ui.theme.min.css">
-  <link rel="stylesheet" href="../js/jquery-ui-AutoComplete.css">
+  <link rel="stylesheet" href="../css/jquery-ui.min.css">
+  <link rel="stylesheet" href="../css/jquery-ui.structure.min.css">
+  <link rel="stylesheet" href="../css/jquery-ui.theme.min.css">
+  <link rel="stylesheet" href="../css/jquery-ui-AutoComplete.css">
 
   <script type="text/javascript" src="../js/jquery-3.2.1.js"></script>
   <script type="text/javascript" src="../js/jquery.dataTables.min.js"></script>

--- a/Website/dashboard/DataQuery.html
+++ b/Website/dashboard/DataQuery.html
@@ -43,20 +43,12 @@
             aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <a class="navbar-brand" href="|">Dashboard</a>
   <div class="collapse navbar-collapse" id="navbarsExampleDefault">
     <ul class="navbar-nav mr-auto">
 	  <li class="nav-item active">
-	    <a class="nav-link" href="|">Home <span class="sr-only">(current)</span></a>
-	  </li>
-	  <li class="nav-item">
-	    <a class="nav-link" href="../index.html">Back</a>
+	    <a class="nav-link" href="../demo/index.html">Back</a>
 	  </li>
     </ul>
-    <form class="form-inline mt-2 mt-md-0">
-      <input class="form-control mr-sm-2" type="text" placeholder="Search">
-      <button class="btn btn-info" type="submit">Search</button>
-    </form>
   </div>
 </nav>
 

--- a/Website/dashboard/MoodleCharts.html
+++ b/Website/dashboard/MoodleCharts.html
@@ -76,11 +76,10 @@
 	  <div id="SemesterAndAssignmentInformation" style="display:none">
 	    <div id="SemesterInformation">
           </br>
-	      <label>Semester start day (YYYYMMDD):</label>
-	      <label id="SemesterStartDay"></label>
+	      <label>Semester start day/end day (YYYYMMDD):</label>
+	      <label id="SemesterStartDay"></label>/
+		  <label id="SemesterEndDay"></label>
 		  </br>
-		  <label>Semester end day (YYYYMMDD):</label>
-	      <label id="SemesterEndDay"></label>
 	    </div>
 	    <div id="AssignmentInformation">
 	    </div>
@@ -401,8 +400,7 @@ function displayAssignmentInformation() {
 		success: function (result) {
 			$("#AssignmentInformation").empty();
 			$.each(result, function (i, p) {
-				$("#AssignmentInformation").append("<p>"+p['AssignmentName']+" start day (YYYYMMDD): "+p['StartDate']+"</p>"); 
-				$("#AssignmentInformation").append("<p>"+p['AssignmentName']+" due day (YYYYMMDD): "+p['DueDate']+"</p>"); 
+				$("#AssignmentInformation").append("<p>"+p['AssignmentName']+" start day/due day (YYYYMMDD): "+p['StartDate']+"/ "+p['DueDate']+"</p>"); 
 			});
 		}//success
 	});//ajax

--- a/Website/dashboard/MoodleCharts.html
+++ b/Website/dashboard/MoodleCharts.html
@@ -30,20 +30,12 @@
             aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <a class="navbar-brand" href="#">Dashboard</a>
   <div class="collapse navbar-collapse" id="navbarsExampleDefault">
     <ul class="navbar-nav mr-auto">
 	  <li class="nav-item active">
-	    <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
-	  </li>
-	  <li class="nav-item">
-	    <a class="nav-link" href="../index.html">Back</a>
+	    <a class="nav-link" href="../demo/index.html">Back</a>
 	  </li>
     </ul>
-    <form class="form-inline mt-2 mt-md-0">
-      <input class="form-control mr-sm-2" type="text" placeholder="Search">
-      <button class="btn btn-info" type="submit">Search</button>
-    </form>
   </div>
 </nav>
 

--- a/Website/dashboard/MoodleCharts.html
+++ b/Website/dashboard/MoodleCharts.html
@@ -71,20 +71,28 @@
 	  <select id="SelectAssignment">
 		<option  id="PleaseSelectAssignment">SelectAssignment</option>
 	  </select>
-	  <div id="SemesterInformation">
-        </br>
-	    <label>Semester start day (YYYYMMDD):</label>
-	    <label id="SemesterStartDay"></label>
-		</br>
-		<label>Semester end day (YYYYMMDD):</label>
-	    <label id="SemesterEndDay"></label>
-	  </div>
-	  <div id="AssignmentInformation">
+	  </br></br>
+	  <button id="Hide">Show/Hide Semester and Assignments start/end day</button>
+	  <div id="SemesterAndAssignmentInformation" style="display:none">
+	    <div id="SemesterInformation">
+          </br>
+	      <label>Semester start day (YYYYMMDD):</label>
+	      <label id="SemesterStartDay"></label>
+		  </br>
+		  <label>Semester end day (YYYYMMDD):</label>
+	      <label id="SemesterEndDay"></label>
+	    </div>
+	    <div id="AssignmentInformation">
+	    </div>
 	  </div>
 	  </br></br>
 	  
 <script type="text/javascript">
 $(document).ready(function() {
+	$("#Hide").click(function(){
+		$("#SemesterAndAssignmentInformation").toggle();
+	});
+
 	//Load data for select course
 	$.ajax({
 		type: "get",

--- a/Website/dashboard/MoodleCharts.html
+++ b/Website/dashboard/MoodleCharts.html
@@ -739,7 +739,7 @@ myChartStudentActivitiesOverview.on('click', function (param) {
 	  <div style="width: 250px;height:100px;position: relative;top: -400px;left: 820px;">
 	    <label for="AllActivitiesOverviewPresentationOrder">Change Presentation Order</label>
 		<select id="AllActivitiesOverviewPresentationOrder">
-		  <option value ="1" selected = "selected">Alphabetical order</option>
+		  <option value ="1" selected = "selected">Chronological order</option>
 		  <option value ="2">Descending order</option>
 		  <option value ="3">Ascending order</option>
 		</select>
@@ -1320,7 +1320,7 @@ myChartEventNamesOverview.on('datazoom', function (params) {
 		</br></br>
 	    <label for="SpecificEventNameOverviewPresentationOrder">Change Presentation Order</label>
 		<select id="SpecificEventNameOverviewPresentationOrder">
-		  <option value ="1" selected = "selected">Alphabetical order</option>
+		  <option value ="1" selected = "selected">Chronological order</option>
 		  <option value ="2">Descending order</option>
 		  <option value ="3">Ascending order</option>
 		</select>
@@ -1929,13 +1929,13 @@ myChartEventContextsOverview.on('datazoom', function (params) {
 		<input type="text" id="SpecificEventContextOverviewAutoCompleteThreshold" value="0">
 		</br></br>
 	    <label for="SpecificEventContextOverviewEventContext">Enter event context (auto-complete)</label>
-		<input type="text" id="SpecificEventContextOverviewEventContext" style="width:520px;">
+		<input type="text" id="SpecificEventContextOverviewEventContext">
 		</br></br>
 		<button type="button" id="SpecificEventContextOverviewSetEventContext">Set Event Context</button>
 		</br></br>
 	    <label for="SpecificEventContextOverviewPresentationOrder">Change Presentation Order</label>
 		<select id="SpecificEventContextOverviewPresentationOrder">
-		  <option value ="1" selected = "selected">Alphabetical order</option>
+		  <option value ="1" selected = "selected">Chronological order</option>
 		  <option value ="2">Descending order</option>
 		  <option value ="3">Ascending order</option>
 		</select>

--- a/Website/dashboard/WebsubmissionCharts.html
+++ b/Website/dashboard/WebsubmissionCharts.html
@@ -24,20 +24,12 @@
             aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <a class="navbar-brand" href="#">Dashboard</a>
   <div class="collapse navbar-collapse" id="navbarsExampleDefault">
     <ul class="navbar-nav mr-auto">
 	  <li class="nav-item active">
-	    <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
-	  </li>
-	  <li class="nav-item">
-	    <a class="nav-link" href="../index.html">Back</a>
+	    <a class="nav-link" href="../demo/index.html">Back</a>
 	  </li>
     </ul>
-    <form class="form-inline mt-2 mt-md-0">
-      <input class="form-control mr-sm-2" type="text" placeholder="Search">
-      <button class="btn btn-info" type="submit">Search</button>
-    </form>
   </div>
 </nav>
 

--- a/Website/dashboard/WebsubmissionCharts.html
+++ b/Website/dashboard/WebsubmissionCharts.html
@@ -65,6 +65,7 @@
 	  <select id="SelectAssignment">
 		<option  id="PleaseSelectAssignment">SelectAssignment</option>
 	  </select>
+	  </br></br></br>
 
 <script type="text/javascript">
 $(document).ready(function() {
@@ -307,7 +308,7 @@ function submissionTimeDistribution5Days(){
 }//function submissionTimeDistribution5Days
 </script>
 
-<!-- the chart Submission Time Distribution 5 days (y-axis: Number of students submit) after and before deadline-->
+<!-- the chart Submission Time Distribution 5 days (y-axis: Number of students) after and before deadline-->
       <div id="SubmissionTimeDistribution5DaysStudent" style="width: 800px;height:400px;"></div>
       <div style="width: 200px;height:100px;position: relative; top: -400px;left: 870px;"></div>
 
@@ -325,7 +326,7 @@ var option = {
 		data: []
 	},
 	yAxis: {
-		name: 'Number of students submit',
+		name: 'Number of students',
 	},
 	dataZoom: [
 		{   // dataZoom component controls x-axis by default
@@ -336,7 +337,7 @@ var option = {
 	],
 	series: [
 		{
-			name: 'Number of students submit',
+			name: 'Number of students',
 			type: 'bar',
 			data: []
 		}
@@ -384,7 +385,7 @@ function submissionTimeDistribution5DaysStudent(){
 				},
 				series: [
 					{
-						name: 'Number of students submit',
+						name: 'Number of students',
 						data: count,
 						markArea: {
 							data: [ 
@@ -538,7 +539,7 @@ function submissionTimeDistribution96Hours(){
 }//function submissionTimeDistribution96Hours
 </script>
 
-     <!-- the chart "Submission Time Distribution 96 hours after and before due hour (y-axis: Number of students submit)"-->
+     <!-- the chart "Submission Time Distribution 96 hours after and before due hour (y-axis: Number of students)"-->
       <div id="SubmissionTimeDistribution96HoursStudent" style="width: 800px;height:400px;"></div>
       <div style="width: 200px;height:100px;position: relative; top: -400px;left: 870px;"></div>
  
@@ -556,7 +557,7 @@ var option = {
 		data: []
 	},
 	yAxis: {
-		name: 'Number of students submit',
+		name: 'Number of students',
 	},
 	dataZoom: [
 		{   // dataZoom component controls x-axis by default
@@ -567,7 +568,7 @@ var option = {
 	],
 	series: [
 		{
-			name: 'Number of students submit',
+			name: 'Number of students',
 			type: 'bar',
 			data: []
 		}
@@ -616,7 +617,7 @@ function submissionTimeDistribution96HoursStudent(){
 				},
 				series: [
 					{
-						name: 'Number of students submit',
+						name: 'Number of students',
 						data: count,
 						markArea: {
 							data: [ 
@@ -781,7 +782,7 @@ function submissionTimeDistributionSubmission(){
 }//function submissionTimeDistributionSubmission
 </script>
 
-      <!-- the chart Submission Time Distribution (y-axis: Number of students submit) -->
+      <!-- the chart Submission Time Distribution (y-axis: Number of students) -->
       <div id="SubmissionTimeDistributionStudent" style="width: 800px;height:400px;"></div>
       <div style="width: 200px;height:100px;position: relative; top: -400px;left: 870px;"></div>
 
@@ -799,7 +800,7 @@ var option = {
 		data: []
 	},
 	yAxis: {
-		name: 'Number of students submit',
+		name: 'Number of students',
 	},
 	dataZoom: [
 		{   // dataZoom component controls x-axis by default
@@ -810,7 +811,7 @@ var option = {
 	],
 	series: [
 		{
-			name: 'Number of students submit',
+			name: 'Number of students',
 			type: 'bar',
 			data: []
 		}
@@ -861,7 +862,7 @@ function submissionTimeDistributionStudent(){
 				},
 				series: [
 					{
-						name: 'Number of students submit',
+						name: 'Number of students',
 						data: count,
 						markArea: {
 							data: [ 

--- a/Website/dashboard/service_test.php
+++ b/Website/dashboard/service_test.php
@@ -3,7 +3,7 @@ require_once dirname(__FILE__).'./service_class.php';
 
 //Development environment: WAMPServer Version 2.2 (PHP 5.3.13, MYSQL 5.5.24)
 //Testing tool: PhpUnit4.8.36
-//Database and data used for testing: studentdata_#168.sql
+//Database and data used for testing: studentdata_#207.sql
 
 class ServiceTest extends PHPUnit_Framework_TestCase 
 {


### PR DESCRIPTION
close #212 

I have made the following changes:
1. Change y-axis name from "Number of students submit" to "Number of students".
2. Move WebSubmission charts a bit down from the drop-down boxes.
3. Provide a button to show/hide semester and assignments start/end day. By default, the information is not displayed. Besides, start/end day of the semester and assignment is compressed into one line.
4. Change the option name from "Alphabetical order" to "Chronological order".
5. Align the text box of auto-complete.
6. Change the button name from "Filter event name and event context" to "Update".
7. Fix link errors and broken links.